### PR TITLE
update for kubernetes 1.24

### DIFF
--- a/helm/elastic-stack/templates/filebeat.yaml
+++ b/helm/elastic-stack/templates/filebeat.yaml
@@ -51,7 +51,7 @@ spec:
         serviceAccountName: filebeat
         priorityClassName: filebeat-pod-critical
         automountServiceAccountToken: true
-        terminationGracePeriodSeconds: 30    
+        terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirstWithHostNet
         hostNetwork: true # Allows to provide richer host metadata
         containers:
@@ -93,35 +93,4 @@ spec:
         - name: ilm-configmap-volume
           configMap:
             name: ilmpolicy-config
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: filebeat
-rules:
-- apiGroups: [""] # "" indicates the core API group
-  resources: ["*"]
-  verbs:
-  - get
-  - watch
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: filebeat
-subjects:
-- kind: ServiceAccount
-  name: filebeat
-  namespace: {{ .Values.namespace }}
-roleRef:
-  kind: ClusterRole
-  name: filebeat
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: filebeat
-  namespace: {{ .Values.namespace }}
 {{- end}}

--- a/helm/elastic-stack/templates/service_account_fb.yaml
+++ b/helm/elastic-stack/templates/service_account_fb.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.filebeat.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: filebeat
+  namespace: {{ .Values.namespace }}
+{{- end }}


### PR DESCRIPTION
dockershim runtime is replaced with containerd runtime in kubernetes 1.24.

Hence, we need to update the path of logs in filebeat configuration.